### PR TITLE
Fix checking for 'as' in import expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ TypescriptDeclarationPlugin.prototype.apply = function(compiler) {
                         line = 'export ' + line;
                     }
                 } else if(line.indexOf('import') == 0) {
-                    if(line.indexOf('as') != -1) {
+                    if(line.indexOf(' as ') != -1) {
                         // Module or UMD Import
                         var matches = _this.regexImportModule.exec(line), importTracked = false;
                         for(var im in imports) {


### PR DESCRIPTION
When checking for the ```as``` keyword in import lines the old check could match lines containing the 'as' characters in either the imported member or the module name. If those lines did not contain an aliasing (the ```as``` keyword itself) the regex match in line 48 would fail and return ```null```.

This solution is not perfect either as there could be cases where the import statement contains ' as ' outside of the aliasing keyword, but it should be enough for most of the cases.